### PR TITLE
Update to libSparkMax v1.1.9

### DIFF
--- a/gen/data.yml
+++ b/gen/data.yml
@@ -259,7 +259,7 @@ CANSparkMaxLowLevel:
     def setParameter(
         self,
         parameterID: ConfigParameter,
-        value: typing.Union[float, int]
+        value: typing.Union[float, bool, int]
     ) -> ParameterStatus:
         """
         .. note:: This function works on a real robot, but has not yet

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ import subprocess
 import sys
 import setuptools
 
-rev_lib_version = "1.1.8"
+rev_lib_version = "1.1.9"
 
 setup_dir = dirname(__file__)
 git_dir = join(setup_dir, ".git")


### PR DESCRIPTION
Makes set()/setReference() calls non-blocking.