### PR TITLE
Hide CANDeviceScanner

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ generate = [
     { CANSparkMax = "rev/CANSparkMax.h" },
 
     { CANAnalog = "rev/CANAnalog.h" },
-    { CANDeviceScanner = "rev/CANDeviceScanner.h" },
+    # { CANDeviceScanner = "rev/CANDeviceScanner.h" },
     { CANDigitalInput = "rev/CANDigitalInput.h" },
     { CANEncoder = "rev/CANEncoder.h" },
     { CANError = "rev/CANError.h" },


### PR DESCRIPTION
REV have said this is an implementation detail of the PC client,
and is moving to a detail namespace in the next version.