### PR TITLE
Update to REVLib 2023.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,17 +6,17 @@ author_email = "robotpy@googlegroups.com"
 url = "https://github.com/robotpy/robotpy-rev"
 license = "BSD-3-Clause"
 install_requires = [
-    "robotpy-wpiutil<2024.0.0,>=2023.0.0b3.post1",
-    "robotpy-wpimath<2024.0.0,>=2023.0.0b3.post1",
-    "wpilib<2024.0.0,>=2023.0.0b3",
+    "robotpy-wpiutil<2024.0.0,>=2023.0.0b7",
+    "robotpy-wpimath<2024.0.0,>=2023.0.0b7",
+    "wpilib<2024.0.0,>=2023.0.0b7",
 ]
 
 [build-system]
 requires = [
-    "robotpy-build<2024.0.0,>=2023.0.0b12",
-    "robotpy-wpiutil<2024.0.0,>=2023.0.0b3.post1",
-    "robotpy-wpimath<2024.0.0,>=2023.0.0b3.post1",
-    "wpilib<2024.0.0,>=2023.0.0b3",
+    "robotpy-build<2024.0.0,>=2023.0.0b16",
+    "robotpy-wpiutil<2024.0.0,>=2023.0.0b7",
+    "robotpy-wpimath<2024.0.0,>=2023.0.0b7",
+    "wpilib<2024.0.0,>=2023.0.0b7",
 ]
 
 [tool.robotpy-build]
@@ -26,14 +26,14 @@ base_package = "rev"
 artifact_id = "REVLib-driver"
 group_id = "com.revrobotics.frc"
 repo_url = "https://maven.revrobotics.com/"
-version = "2023.0.0"
+version = "2023.0.1"
 libs = ["REVLibDriver"]
 
 [tool.robotpy-build.static_libs."revlib".maven_lib_download]
 artifact_id = "REVLib-cpp"
 group_id = "com.revrobotics.frc"
 repo_url = "https://maven.revrobotics.com/"
-version = "2023.0.0"
+version = "2023.0.1"
 libs = ["REVLib"]
 
 [tool.robotpy-build.wrappers."rev"]


### PR DESCRIPTION
Also updates other dependencies:

- robotpy-build >= 2023.0.0b16
- robotpy-wpimath >= 2023.0.0b7
- robotpy-wpiutil >= 2023.0.0b7
- wpilib >= 2023.0.0b7

https://github.com/REVrobotics/REV-Software-Binaries/releases/tag/revlib-2023.0.1

### Changelog

- Adds support for osxuniversal