### PR TITLE
Update to REVLib 2023.1.3

### DIFF
--- a/examples/color_match/robot.py
+++ b/examples/color_match/robot.py
@@ -38,7 +38,6 @@ class MyRobot(wpilib.TimedRobot):
         self.colorMatcher.addColorMatch(self.yellowTarget)
 
     def robotPeriodic(self):
-
         # The method GetColor() returns a normalized color value from the sensor and can be
         # useful if outputting the color to an RGB LED or similar. To
         # read the raw color, use GetRawColor().

--- a/examples/read_rgb_values/robot.py
+++ b/examples/read_rgb_values/robot.py
@@ -19,7 +19,6 @@ class MyRobot(wpilib.TimedRobot):
         self.colorSensor = ColorSensorV3(wpilib.I2C.Port.kOnboard)
 
     def robotPeriodic(self):
-
         # The method getColor() returns a normalized color value from the sensor and can be
         # useful if outputting the color to an RGB LED or similar. To
         # read the raw color, use getRawColor().

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,14 +26,14 @@ base_package = "rev"
 artifact_id = "REVLib-driver"
 group_id = "com.revrobotics.frc"
 repo_url = "https://maven.revrobotics.com"
-version = "2023.1.2"
+version = "2023.1.3"
 libs = ["REVLibDriver"]
 
 [tool.robotpy-build.static_libs."revlib".maven_lib_download]
 artifact_id = "REVLib-cpp"
 group_id = "com.revrobotics.frc"
 repo_url = "https://maven.revrobotics.com"
-version = "2023.1.2"
+version = "2023.1.3"
 libs = ["REVLib"]
 
 [tool.robotpy-build.wrappers."rev"]

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -6,7 +6,6 @@ import sys
 import subprocess
 
 if __name__ == "__main__":
-
     root = abspath(dirname(__file__))
     os.chdir(root)
 


### PR DESCRIPTION
https://github.com/REVrobotics/REV-Software-Binaries/releases/tag/revlib-2023.1.3

> This version of REVLib requires SPARK MAX Firmware v1.6.3. Please update your SPARK MAX through the REV Hardware Client to use with REVLib 2023.1.3.
>
> - Improves documentation for the setZeroOffset() and getZeroOffset() methods on Absolute Encoder objects
> - Fixes issue where reading an absolute encoder’s zero offset could return an incorrect value in certain conditions
